### PR TITLE
simplify debounce

### DIFF
--- a/javascript/updates_for_element.js
+++ b/javascript/updates_for_element.js
@@ -2,7 +2,7 @@ import morphdom from 'morphdom'
 import { shouldMorph } from './morph_callbacks'
 import activeElement from './active_element'
 import actionCable from './action_cable'
-import { assignFocus, dispatch } from './utils'
+import { Boris, assignFocus, dispatch } from './utils'
 
 const template = `
 <style>
@@ -12,15 +12,6 @@ const template = `
 </style>
 <slot></slot>
 `
-
-// Boris de bouncer
-function Boris (func, timeout) {
-  let timer
-  return (...args) => {
-    clearTimeout(timer)
-    timer = setTimeout(() => func.apply(this, args), timeout)
-  }
-}
 
 class UpdatesForElement extends HTMLElement {
   constructor () {

--- a/javascript/updates_for_element.js
+++ b/javascript/updates_for_element.js
@@ -41,6 +41,10 @@ class UpdatesForElement extends HTMLElement {
     }
   }
 
+  disconnectedCallback () {
+    if (this.channel) this.channel.unsubscribe()
+  }
+
   update () {
     const identifier = this.getAttribute('identifier')
     const query = `updates-for[identifier="${identifier}"]`
@@ -72,8 +76,8 @@ class UpdatesForElement extends HTMLElement {
       })
   }
 
-  disconnectedCallback () {
-    if (this.channel) this.channel.unsubscribe()
+  get url () {
+    return this.hasAttribute('url') ? this.getAttribute('url') : location.href
   }
 
   get preview () {
@@ -81,10 +85,6 @@ class UpdatesForElement extends HTMLElement {
       document.documentElement.hasAttribute('data-turbolinks-preview') ||
       document.documentElement.hasAttribute('data-turbo-preview')
     )
-  }
-
-  get url () {
-    return this.hasAttribute('url') ? this.getAttribute('url') : location.href
   }
 
   get debounce () {

--- a/javascript/updates_for_element.js
+++ b/javascript/updates_for_element.js
@@ -45,35 +45,34 @@ class UpdatesForElement extends HTMLElement {
     if (this.channel) this.channel.unsubscribe()
   }
 
-  update () {
+  async update () {
     const identifier = this.getAttribute('identifier')
     const query = `updates-for[identifier="${identifier}"]`
     const blocks = document.querySelectorAll(query)
     if (blocks[0] !== this) return
 
     const template = document.createElement('template')
-    fetch(this.url)
-      .then(response => response.text())
-      .then(html => {
-        template.innerHTML = String(html).trim()
-        const fragments = template.content.querySelectorAll(query)
-        for (let i = 0; i < blocks.length; i++) {
-          activeElement.set(document.activeElement)
-          const operation = {
-            element: blocks[i],
-            html: fragments[i],
-            permanentAttributeName: 'data-ignore-updates',
-            focusSelector: null
-          }
-          dispatch(blocks[i], 'cable-ready:before-update', operation)
-          morphdom(blocks[i], fragments[i], {
-            childrenOnly: true,
-            onBeforeElUpdated: shouldMorph(operation)
-          })
-          dispatch(blocks[i], 'cable-ready:after-update', operation)
-          assignFocus(operation.focusSelector)
-        }
+    const response = await fetch(this.url)
+    const html = await response.text()
+
+    template.innerHTML = String(html).trim()
+    const fragments = template.content.querySelectorAll(query)
+    for (let i = 0; i < blocks.length; i++) {
+      activeElement.set(document.activeElement)
+      const operation = {
+        element: blocks[i],
+        html: fragments[i],
+        permanentAttributeName: 'data-ignore-updates',
+        focusSelector: null
+      }
+      dispatch(blocks[i], 'cable-ready:before-update', operation)
+      morphdom(blocks[i], fragments[i], {
+        childrenOnly: true,
+        onBeforeElUpdated: shouldMorph(operation)
       })
+      dispatch(blocks[i], 'cable-ready:after-update', operation)
+      assignFocus(operation.focusSelector)
+    }
   }
 
   get url () {

--- a/javascript/utils.js
+++ b/javascript/utils.js
@@ -101,6 +101,15 @@ const after = (target, operation) =>
     operation
   )
 
+// Boris de bouncer
+function Boris (func, timeout) {
+  let timer
+  return (...args) => {
+    clearTimeout(timer)
+    timer = setTimeout(() => func.apply(this, args), timeout)
+  }
+}
+
 export {
   isTextInput,
   assignFocus,
@@ -110,5 +119,6 @@ export {
   processElements,
   operate,
   before,
-  after
+  after,
+  Boris
 }


### PR DESCRIPTION
Conceptually, I think debounce is the right call. I just think we can approach it differently.

This implementation adds a bog-standard debouncer function called `Boris` to `utils.js`, and it gets used in the web component to bless the `update` method so that it is properly debounced without needing to introduce the complexity and memory overhead of event handling into the scenario.

The other simplification is that to the very best of my understanding, there is no scenario in which there could be more than one identifier. If I'm missing something, please let me know.